### PR TITLE
Update widgets.py

### DIFF
--- a/Custom_Widgets/widgets.py
+++ b/Custom_Widgets/widgets.py
@@ -137,6 +137,7 @@ class QCustomQPushButton(QtWidgets.QPushButton):
     def setObjectCustomTheme(self, color1, color2):
         self.color1 = QtGui.QColor(color1)
         self.color2 = QtGui.QColor(color2)
+        self._animate(0)
 
     ########################################################################
     ## SET BUTTON ANIMATION


### PR DESCRIPTION
To apply the CustomTheme immediately. 

Otherwise:
When a QCustomPushButton has no definition of "defaultStyle" and "fallbackStyle" , the .setObjectCustomTheme() won't set a new Theme to the button untill the mouse hovering action has been took place.