### PR TITLE
Resolution of QPushButtons exemple error '''Exception: ('QPushButton'…

### DIFF
--- a/examples/QPushButtons/interface.ui
+++ b/examples/QPushButtons/interface.ui
@@ -16,21 +16,21 @@
   <widget class="QWidget" name="centralwidget">
    <layout class="QHBoxLayout" name="horizontalLayout">
     <item>
-     <widget class="QPushButton" name="pushButton">
+     <widget class="QCustomQPushButton" name="pushButton">
       <property name="text">
        <string>PushButton 1</string>
       </property>
      </widget>
     </item>
     <item>
-     <widget class="QPushButton" name="pushButton_2">
+     <widget class="QCustomQPushButton" name="pushButton_2">
       <property name="text">
        <string>PushButton 2</string>
       </property>
      </widget>
     </item>
     <item>
-     <widget class="QPushButton" name="pushButton_3">
+     <widget class="QCustomQPushButton" name="pushButton_3">
       <property name="text">
        <string>PushButton 3</string>
       </property>
@@ -39,6 +39,13 @@
    </layout>
   </widget>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QCustomQPushButton</class>
+   <extends>QPushButton</extends>
+   <header location="global">Custom_Widgets.Widgets.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/examples/QPushButtons/ui_interface.py
+++ b/examples/QPushButtons/ui_interface.py
@@ -23,17 +23,17 @@ class Ui_MainWindow(object):
         self.centralwidget.setObjectName(u"centralwidget")
         self.horizontalLayout = QHBoxLayout(self.centralwidget)
         self.horizontalLayout.setObjectName(u"horizontalLayout")
-        self.pushButton = QPushButton(self.centralwidget)
+        self.pushButton = QCustomQPushButton(self.centralwidget)
         self.pushButton.setObjectName(u"pushButton")
 
         self.horizontalLayout.addWidget(self.pushButton)
 
-        self.pushButton_2 = QPushButton(self.centralwidget)
+        self.pushButton_2 = QCustomQPushButton(self.centralwidget)
         self.pushButton_2.setObjectName(u"pushButton_2")
 
         self.horizontalLayout.addWidget(self.pushButton_2)
 
-        self.pushButton_3 = QPushButton(self.centralwidget)
+        self.pushButton_3 = QCustomQPushButton(self.centralwidget)
         self.pushButton_3.setObjectName(u"pushButton_3")
 
         self.horizontalLayout.addWidget(self.pushButton_3)


### PR DESCRIPTION
Hello,

I tried to test the QPushButtons example and I received this error : 
'''
Traceback (most recent call last):
  File "C:\Users\engineering\sandbox-python3\exemple\QT-PyQt-PySide-Custom-Widgets\examples\QPushButtons\main.py", line 161, in <module>
    window = MainWindow()
  File "C:\Users\engineering\sandbox-python3\exemple\QT-PyQt-PySide-Custom-Widgets\examples\QPushButtons\main.py", line 40, in __init__
    loadJsonStyle(self, self.ui)
  File "C:\Users\engineering\AppData\Local\Programs\Python\Python310\lib\site-packages\Custom_Widgets\Widgets.py", line 2271, in loadJsonStyle
    raise Exception(buttonObject.metaObject().className(), buttonObject, " is not of type QPushButton")
Exception: ('QPushButton', <PySide2.QtWidgets.QPushButton(0x1c4e8ba8c70, name="pushButton") at 0x000001C4E9E58080>, ' is not of type QPushButton')
'''

After some search, I discovered that the buttons in the .ui file were simple QPushButton but not QCustomQPushButton.
I, then, modified "ui_interface.py" and "interface.ui" to conform to the custom button.

The example works fine in my context now.

Best regards,

t-brunet