### PR TITLE
Remove unused PySide6.QtGui import

### DIFF
--- a/Custom_Widgets/Qss/SvgToPngIcons.py
+++ b/Custom_Widgets/Qss/SvgToPngIcons.py
@@ -32,8 +32,6 @@ from qtpy.QtCore import *
 
 from Custom_Widgets.Log import *
 
-from PySide6.QtGui import QColor
-
 class NewIconsGenerator(QObject):
     def __init__(self, arg):
         super(NewIconsGenerator, self).__init__()


### PR DESCRIPTION
This removes an unused import of `QColor` from `PySide6.QtGui`, which causes conflict errors with pyinstaller for users using only `PyQt5`. Thanks!
